### PR TITLE
Updating node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: The id of a transition to apply to the issue
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: './dist/index.js'


### PR DESCRIPTION
As per [Github's own blog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), we need to upgrade to Node 16 before Summer 2023 when they remove all Node 12 actions.