### PR TITLE
docs(readme): broken link to find-issue-key action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Example transition action:
 }
 ```
 
-The `issue` parameter can be an issue id created or retrieved by an upstream action – for example, [`Create`](https://github.com/marketplace/actions/jira-create) or [`Find Issue Key`](https://github.com/marketplace/actions/jira-find). Here is full example workflow:
+The `issue` parameter can be an issue id created or retrieved by an upstream action – for example, [`Create`](https://github.com/marketplace/actions/jira-create) or [`Find Issue Key`](https://github.com/marketplace/actions/jira-find-issue-key). Here is full example workflow:
 
 ```yaml
 on:


### PR DESCRIPTION
**What's in this PR?**
- There is a broken link, sending to a 404 page. This PR's changes the link redirecting to the right repo/action page 😄 